### PR TITLE
feat: update AppVersion when helm_update_appversion is set

### DIFF
--- a/pkg/updater/helm_test.go
+++ b/pkg/updater/helm_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-func TestNpmUpdater(t *testing.T) {
+func TestHelmUpdater(t *testing.T) {
 	require := require.New(t)
 
 	updater := &Updater{}
@@ -20,4 +21,28 @@ func TestNpmUpdater(t *testing.T) {
 	f, err := os.OpenFile(chartPath, os.O_RDONLY, 0)
 	require.NoError(err)
 	defer f.Close()
+}
+
+func TestHelmUpdaterAppVersion(t *testing.T) {
+	require := require.New(t)
+
+	updater := &Updater{}
+
+	conf := map[string]string{
+		"helm_update_appversion": "true",
+	}
+	updater.Init(conf)
+
+	nVer := "1.2.3"
+	chartPath := "../../test/Chart.yaml"
+
+	err := updater.Apply(chartPath, nVer)
+	require.NoError(err)
+	f, err := os.ReadFile(chartPath)
+	require.NoError(err)
+
+	data := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(f, &data)
+	require.NoError(err)
+	require.Equal("v1.2.3", data["appVersion"])
 }


### PR DESCRIPTION
Add support for updating `appVersion` when the `helm_update_appversion` config is set to `"true"`.

Per default it prefixes the `appVersion` with `v` but this can be configured by specifying a format string in `helm_appversion_template`.

I'll be happy to address any changes if needed. I'm very much looking forward to getting rid of several `yq` hacks in my repos.

Fixes #1 